### PR TITLE
feat: Semantic Version conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/goplus/llpkg
 
-go 1.20
+go 1.21
+
+toolchain go1.21.13
+
+require github.com/Masterminds/semver/v3 v3.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/goplus/llpkg
 
-go 1.21
-
-toolchain go1.21.13
+go 1.20
 
 require github.com/Masterminds/semver/v3 v3.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=

--- a/llpkg-tool/pkg/version/semVer.go
+++ b/llpkg-tool/pkg/version/semVer.go
@@ -1,4 +1,4 @@
-package tools
+package version
 
 import (
 	"errors"

--- a/llpkg-tool/pkg/version/semVer.go
+++ b/llpkg-tool/pkg/version/semVer.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	sem "github.com/Masterminds/semver/v3"
+)
+
+// Convert any C version into SemVer
+func ToSemVer(ver string) (*sem.Version, error) {
+	//At least two parts, "2","v1","20230607" are not allowed
+	twoPartVer := regexp.MustCompile(`^v?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+	if !twoPartVer.MatchString(ver) {
+		return insertVer(ver)
+	}
+	//Convert some “looks like SemVer” version numbers (v1.2.0, 1.3, etc) into SemVer
+	v, err := sem.NewVersion(ver)
+	if err != nil {
+		return insertVer(ver)
+	}
+	return v, nil
+}
+
+// Add orginal version that is not SemVer to the pre-release part of "1.0.0"
+func insertVer(ver string) (*sem.Version, error) {
+	metaVersion := regexp.MustCompile(`^.+(\+).+$`)
+	var newVer string
+	//Before add to the pre-release part, add "-llgo" suffix before "+" (if exists), and replace "." with "-"
+	if metaVersion.MatchString(ver) {
+		newVer = strings.Replace(ver, "+", "-llgo+", 1)
+		newVer = fmt.Sprintf("1.0.0-%s", strings.ReplaceAll(newVer, ".", "-"))
+	} else {
+		newVer = fmt.Sprintf("1.0.0-%s-llgo", strings.ReplaceAll(ver, ".", "-"))
+	}
+	version, err := sem.StrictNewVersion(newVer)
+	if err != nil {
+		return nil, errors.New("Fail to convert " + ver)
+	} else {
+		return version, nil
+	}
+}


### PR DESCRIPTION
# Conversion
- Use the original version if it obeys SemVer.
- Try to convert into SemVer if it doesn't obey SemVer.
## Rules
- Versions like `v1.2.3`, `1.2.3`, `2025.2.11` would be accepted as SemVer.
- Versions like `v1.2`, `1.2` would be convert into SemVer, for example, `1.2.0`.
- Versions like `v1`, `0064`, `cci.20250211` and `2025.02.11` would be convert into `1.0.0-v1-llgo`, `1.0.0-0064-llgo`, `1.0.0-cci-20250211-llgo` and `1.0.0-2025-02-11-llgo`.
- Versions which are not SemVer and have metadata or `+` like `v1+good` would be convert into `1.0.0-v1-llgo+good`.