### PR TITLE
Change the format of non-SemVer conversion

### DIFF
--- a/llpkg-tool/pkg/version/semVer.go
+++ b/llpkg-tool/pkg/version/semVer.go
@@ -6,18 +6,18 @@ import (
 	"regexp"
 	"strings"
 
-	sem "github.com/Masterminds/semver/v3"
+	"github.com/Masterminds/semver/v3"
 )
 
 // Convert any C version into SemVer
-func ToSemVer(ver string) (*sem.Version, error) {
-	//At least two parts, "2","v1","20230607" are not allowed
+func ToSemVer(ver string) (*semver.Version, error) {
+	//At least two parts, "2","v1","20230607" would not be considered as SemVer
 	twoPartVer := regexp.MustCompile(`^v?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 	if !twoPartVer.MatchString(ver) {
 		return insertVer(ver)
 	}
 	//Convert some “looks like SemVer” version numbers (v1.2.0, 1.3, etc) into SemVer
-	v, err := sem.NewVersion(ver)
+	v, err := semver.NewVersion(ver)
 	if err != nil {
 		return insertVer(ver)
 	}
@@ -25,17 +25,10 @@ func ToSemVer(ver string) (*sem.Version, error) {
 }
 
 // Add orginal version that is not SemVer to the pre-release part of "1.0.0"
-func insertVer(ver string) (*sem.Version, error) {
-	metaVersion := regexp.MustCompile(`^.+(\+).+$`)
-	var newVer string
-	//Before add to the pre-release part, add "-llgo" suffix before "+" (if exists), and replace "." with "-"
-	if metaVersion.MatchString(ver) {
-		newVer = strings.Replace(ver, "+", "-llgo+", 1)
-		newVer = fmt.Sprintf("1.0.0-%s", strings.ReplaceAll(newVer, ".", "-"))
-	} else {
-		newVer = fmt.Sprintf("1.0.0-%s-llgo", strings.ReplaceAll(ver, ".", "-"))
-	}
-	version, err := sem.StrictNewVersion(newVer)
+func insertVer(ver string) (*semver.Version, error) {
+	//Before add to the pre-release part, replace "." with "-"
+	newVer := fmt.Sprintf("0.0.0-0-%s", strings.ReplaceAll(ver, ".", "-"))
+	version, err := semver.StrictNewVersion(newVer)
 	if err != nil {
 		return nil, errors.New("Fail to convert " + ver)
 	} else {

--- a/llpkg-tool/pkg/version/semVer.go
+++ b/llpkg-tool/pkg/version/semVer.go
@@ -11,6 +11,9 @@ import (
 
 // Convert any C version into SemVer
 func ToSemVer(ver string) (*semver.Version, error) {
+	if strings.Trim(ver, " ") == "" {
+		return nil, errors.New("empty version")
+	}
 	//At least two parts, "2","v1","20230607" would not be considered as SemVer
 	twoPartVer := regexp.MustCompile(`^v?(0|[1-9]\d*)(?:\.(0|[1-9]\d*))(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 	if !twoPartVer.MatchString(ver) {
@@ -30,7 +33,7 @@ func insertVer(ver string) (*semver.Version, error) {
 	newVer := fmt.Sprintf("0.0.0-0-%s", strings.ReplaceAll(ver, ".", "-"))
 	version, err := semver.StrictNewVersion(newVer)
 	if err != nil {
-		return nil, errors.New("Fail to convert " + ver)
+		return nil, errors.New("fail to convert " + ver)
 	} else {
 		return version, nil
 	}


### PR DESCRIPTION
# Background
Previously, we tried to add the `-llgo` suffix at the end of the pre-release version part of `1.0.0`. However, we find out that this kind of suffix is way too complicated and isn't necessary. And it could be replaced with prefixes like `0-` or `--`. Major part of `1.0.0` implies that it is a **stable version**, and when it shouldn't be, it will cause the problem.

After discussion, we chose `0-`. As a result, versions like 0065+meta would be converted to `0.0.0-0-0065+meta` instead of `1.0.0-0065-llgo+meta`